### PR TITLE
Add support for computing SDF gradient for point clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,7 @@ Number of points to sample when using `surface_point_method='sample'`
 - `normal_sample_count`:
 Number of nearby surface points to check when using `sign_method='normal'`.
 The sign of the resulting SDF is determined by majority vote.
+
+- `return_gradients`
+Produce the gradient of the SDF along with the SDF itself. Changes the output from a
+`np.ndarray` to `(np.ndarray, np.ndarray)` of shapes `(N)` and `(N, 3)` respectively.

--- a/mesh_to_sdf/__init__.py
+++ b/mesh_to_sdf/__init__.py
@@ -41,21 +41,21 @@ def mesh_to_sdf(mesh, query_points, surface_point_method='scan', sign_method='no
         raise ValueError('Unknown sign determination method: {:s}'.format(sign_method))
 
 
-def mesh_to_voxels(mesh, voxel_resolution=64, surface_point_method='scan', sign_method='normal', scan_count=100, scan_resolution=400, sample_point_count=10000000, normal_sample_count=11, pad=False, check_result=False):
+def mesh_to_voxels(mesh, voxel_resolution=64, surface_point_method='scan', sign_method='normal', scan_count=100, scan_resolution=400, sample_point_count=10000000, normal_sample_count=11, pad=False, check_result=False, return_gradients=False):
     mesh = scale_to_unit_cube(mesh)
 
     surface_point_cloud = get_surface_point_cloud(mesh, surface_point_method, 3**0.5, scan_count, scan_resolution, sample_point_count, sign_method=='normal')
 
-    return surface_point_cloud.get_voxels(voxel_resolution, sign_method=='depth', normal_sample_count, pad, check_result)
+    return surface_point_cloud.get_voxels(voxel_resolution, sign_method=='depth', normal_sample_count, pad, check_result, return_gradients)
 
 # Sample some uniform points and some normally distributed around the surface as proposed in the DeepSDF paper
-def sample_sdf_near_surface(mesh, number_of_points = 500000, surface_point_method='scan', sign_method='normal', scan_count=100, scan_resolution=400, sample_point_count=10000000, normal_sample_count=11, min_size=0):
+def sample_sdf_near_surface(mesh, number_of_points = 500000, surface_point_method='scan', sign_method='normal', scan_count=100, scan_resolution=400, sample_point_count=10000000, normal_sample_count=11, min_size=0, return_gradients=False):
     mesh = scale_to_unit_sphere(mesh)
     
     if surface_point_method == 'sample' and sign_method == 'depth':
         print("Incompatible methods for sampling points and determining sign, using sign_method='normal' instead.")
         sign_method = 'normal'
 
-    surface_point_cloud = get_surface_point_cloud(mesh, surface_point_method, 1, scan_count, scan_resolution, sample_point_count, calculate_normals=sign_method=='normal')
+    surface_point_cloud = get_surface_point_cloud(mesh, surface_point_method, 1, scan_count, scan_resolution, sample_point_count, calculate_normals=sign_method=='normal' or return_gradients)
 
-    return surface_point_cloud.sample_sdf_near_surface(number_of_points, surface_point_method=='scan', sign_method, normal_sample_count, min_size)
+    return surface_point_cloud.sample_sdf_near_surface(number_of_points, surface_point_method=='scan', sign_method, normal_sample_count, min_size, return_gradients)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setuptools.setup(
     install_requires=[
         'pyopengl',
         'pyrender',
-        'scikit-image'
+        'scikit-image',
+        'sklearn',
     ]
 )


### PR DESCRIPTION
[SIREN](https://vsitzmann.github.io/siren/) showcases an [example](https://github.com/vsitzmann/siren/blob/4df34baee3f0f9c8f351630992c1fe1f69114b5f/loss_functions.py#L214) where they use the gradient of the SDF during training. The gradient is the spatial partial derivative of the SDF, closely related to the normal vector.

This PR adds the ability to compute the gradient along with the SDF samples. This solution sould be simple to expand to voxel models.


Example:
![sdf](https://user-images.githubusercontent.com/140964/109530740-55155f80-7ab7-11eb-99c1-3355c3aa5d49.png)
![sdf_grad](https://user-images.githubusercontent.com/140964/109530743-55adf600-7ab7-11eb-927c-d21c2425eb5e.png)

