### PR TITLE
surface_point_cloud: Add option to set unit sphere radius

### DIFF
--- a/mesh_to_sdf/surface_point_cloud.py
+++ b/mesh_to_sdf/surface_point_cloud.py
@@ -102,15 +102,16 @@ class SurfacePointCloud:
         else:
             return voxels
 
-    def sample_sdf_near_surface(self, number_of_points=500000, use_scans=True, sign_method='normal', normal_sample_count=11, min_size=0, return_gradients=False):
+    def sample_sdf_near_surface(self, number_of_points=500000, use_scans=True, sign_method='normal', normal_sample_count=11, min_size=0, return_gradients=False, surface_sample_frac=47/50, sphere_radius=1):
         query_points = []
-        surface_sample_count = int(number_of_points * 47 / 50) // 2
+        surface_sample_count = int(number_of_points * surface_sample_frac) // 2
         surface_points = self.get_random_surface_points(surface_sample_count, use_scans=use_scans)
         query_points.append(surface_points + np.random.normal(scale=0.0025, size=(surface_sample_count, 3)))
         query_points.append(surface_points + np.random.normal(scale=0.00025, size=(surface_sample_count, 3)))
         
         unit_sphere_sample_count = number_of_points - surface_points.shape[0] * 2
         unit_sphere_points = sample_uniform_points_in_unit_sphere(unit_sphere_sample_count)
+        if sphere_radius != 1: unit_sphere_points *= sphere_radius
         query_points.append(unit_sphere_points)
         query_points = np.concatenate(query_points).astype(np.float32)
 


### PR DESCRIPTION
This PR adds the option to configure a custom radius for the volumetric samples in the `SurfacePointCloud.sample_sdf_near_surface` procedure.
In addition, it also makes the ratio of sphere and near-surface points configurable.

How does `sign_method == 'depth'` deal with point behind the cameras? I assume they either get a "negative" depths?
If they instead get clipped then this PR will need more work.
