### PR TITLE
Add auto_scaling parameter for scaling the mesh inside the unit sphere

### DIFF
--- a/mesh_to_sdf/__init__.py
+++ b/mesh_to_sdf/__init__.py
@@ -49,8 +49,8 @@ def mesh_to_voxels(mesh, voxel_resolution=64, surface_point_method='scan', sign_
     return surface_point_cloud.get_voxels(voxel_resolution, sign_method=='depth', normal_sample_count, pad, check_result, return_gradients)
 
 # Sample some uniform points and some normally distributed around the surface as proposed in the DeepSDF paper
-def sample_sdf_near_surface(mesh, number_of_points = 500000, surface_point_method='scan', sign_method='normal', scan_count=100, scan_resolution=400, sample_point_count=10000000, normal_sample_count=11, min_size=0, return_gradients=False):
-    mesh = scale_to_unit_sphere(mesh)
+def sample_sdf_near_surface(mesh, number_of_points = 500000, surface_point_method='scan', sign_method='normal', scan_count=100, scan_resolution=400, sample_point_count=10000000, normal_sample_count=11, min_size=0, return_gradients=False, fixed_scaling=False):
+    mesh = scale_to_unit_sphere(mesh, fixed_scaling)
     
     if surface_point_method == 'sample' and sign_method == 'depth':
         print("Incompatible methods for sampling points and determining sign, using sign_method='normal' instead.")

--- a/mesh_to_sdf/__init__.py
+++ b/mesh_to_sdf/__init__.py
@@ -49,8 +49,8 @@ def mesh_to_voxels(mesh, voxel_resolution=64, surface_point_method='scan', sign_
     return surface_point_cloud.get_voxels(voxel_resolution, sign_method=='depth', normal_sample_count, pad, check_result, return_gradients)
 
 # Sample some uniform points and some normally distributed around the surface as proposed in the DeepSDF paper
-def sample_sdf_near_surface(mesh, number_of_points = 500000, surface_point_method='scan', sign_method='normal', scan_count=100, scan_resolution=400, sample_point_count=10000000, normal_sample_count=11, min_size=0, return_gradients=False, fixed_scaling=False):
-    mesh = scale_to_unit_sphere(mesh, fixed_scaling)
+def sample_sdf_near_surface(mesh, number_of_points = 500000, surface_point_method='scan', sign_method='normal', scan_count=100, scan_resolution=400, sample_point_count=10000000, normal_sample_count=11, min_size=0, return_gradients=False, auto_scaling=True, scale_ratio=1):
+    mesh = scale_to_unit_sphere(mesh, auto_scaling, scale_ratio)
     
     if surface_point_method == 'sample' and sign_method == 'depth':
         print("Incompatible methods for sampling points and determining sign, using sign_method='normal' instead.")

--- a/mesh_to_sdf/utils.py
+++ b/mesh_to_sdf/utils.py
@@ -2,16 +2,16 @@ import functools
 import trimesh
 import numpy as np
 
-def scale_to_unit_sphere(mesh, fixed_scaling):
+def scale_to_unit_sphere(mesh, auto_scaling, scale_ratio):
     if isinstance(mesh, trimesh.Scene):
         mesh = mesh.dump().sum()
 
     vertices = mesh.vertices - mesh.bounding_box.centroid
-    if not fixed_scaling:
+    if auto_scaling:
         distances = np.linalg.norm(vertices, axis=1)
         vertices /= np.max(distances)
     else:
-        vertices /= 1.414   # this is the maximum possible ratio between the original and scaled mesh
+        vertices /= scale_ratio   # ratio between the original mesh and the scaled mesh inside the unit sphere
 
     return trimesh.Trimesh(vertices=vertices, faces=mesh.faces)
 

--- a/mesh_to_sdf/utils.py
+++ b/mesh_to_sdf/utils.py
@@ -2,13 +2,16 @@ import functools
 import trimesh
 import numpy as np
 
-def scale_to_unit_sphere(mesh):
+def scale_to_unit_sphere(mesh, fixed_scaling):
     if isinstance(mesh, trimesh.Scene):
         mesh = mesh.dump().sum()
 
     vertices = mesh.vertices - mesh.bounding_box.centroid
-    distances = np.linalg.norm(vertices, axis=1)
-    vertices /= np.max(distances)
+    if not fixed_scaling:
+        distances = np.linalg.norm(vertices, axis=1)
+        vertices /= np.max(distances)
+    else:
+        vertices /= 1.414   # this is the maximum possible ratio between the original and scaled mesh
 
     return trimesh.Trimesh(vertices=vertices, faces=mesh.faces)
 


### PR DESCRIPTION
# Problem statement
When the method `sample_sdf_near_surface(..)` is called, the mesh is first scaled to fit into a unit sphere. The scaling ratio is not fixed, as it depends on the object geometry - which means that different objects are scaled differently. While in the virtual domain this is not a problem, as we can extract geometry information from the simulator, a geometry-dependent scaling ratio is a problem in the real world, where we cannot extract geometry information from the object easily. Therefore, it is essential to have a way to keep the scaling ratio fixed for all the objects in our dataset. Moreover, having control over the scaling ratio could be beneficial in the virtual domain as well.

# Changes
This PR adds two parameters to the methods `sample_sdf_near_surface(..)` and `scale_to_unit_sphere(..)` :
- `auto_scaling`: when `True`, the mesh is automatically scaled to fit into a unit sphere. Thus, nothing changes from the current repository. When `False`, the mesh is scaled according to the parameter `scale_ratio`. 
- `scale_ratio`: this parameter is used to scale the original mesh when the method `scale_to_unit_sphere(..)` is called. This parameter allows to have control over the scaling procedure.

# Example
```
# sample from mesh_1 and mesh_2, keeping the ratio between the original and resulting mesh fixed at 1.3
samples_1 = mesh_to_sdf.sample_sdf_near_surface(mesh_1, auto_scaling=False, scale_ratio = 1.3)[0]
samples_2 = mesh_to_sdf.sample_sdf_near_surface(mesh_2, auto_scaling=False, scale_ratio = 1.3)[0]

# plot the samples
fig = plotly.graph_objects.Figure(
            [   go.Scatter3d(
                     x=samples_1[:, 0], y=samples_1[:, 1],  z=samples_1[:, 2], 
                     mode='markers', marker=dict(size=1, color='darkblue') ),
                 go.Scatter3d(
                     x=samples_2[:, 0], y=samples_2[:, 1], z=samples_2[:, 2], 
                     mode='markers', marker=dict(size=1, color='orange')  )
            ]
        )
fig.show()
```
![image](https://user-images.githubusercontent.com/30290271/205714771-3aa0ea2b-10c6-459c-b56d-46b9c0268498.png)

Both objects have been scaled by the same ratio, therefore we can use the DeepSDF method in downstream tasks in the real world.

I hope this makes sense, I am happy answer any questions you may have about this PR.